### PR TITLE
Add type definitions to package exports

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -19,6 +19,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/vue-datetime.mjs",
       "require": "./dist/vue-datetime.umd.js"
     },


### PR DESCRIPTION
Typescript type definitions are not exported. This results in an error when importing `vue-datetime3` in a Typescript project.

```
Could not find a declaration file for module 'vue-datetime3'.
'<path>/node_modules/vue-datetime3/dist/vue-datetime.mjs' implicitly has an 'any' type.
There are types at '<path>/node_modules/vue-datetime3/dist/index.d.ts', but this result
could not be resolved when respecting package.json "exports". The 'vue-datetime3' library
may need to update its package.json or typings
```

This is easily solved by adding a type export to package.json.